### PR TITLE
Add dry-run mode for other exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,8 @@
     6. Create
     7. Download `client_secret.json`
 4. [Add your e-mail address as Test user](https://console.cloud.google.com/apis/credentials/consent)
+
+
+## Tips:
+
+You can use `--dry-run` mode to export playlist to Spotify with [spotlistr.com](https://www.spotlistr.com/search/textbox).


### PR DESCRIPTION
The `--dry-run` mode will read the playlist without making any requests to the YouTube API. Instead, this mode will allow for printing the entire playlist in a human-readable format.

You can use it to export playlist to Spotify with [spotlistr.com](https://www.spotlistr.com/search/textbox).